### PR TITLE
SAN-4010 Update Swarm

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,8 @@ Swarmerode._parseSwarmSystemStatus = function (systemStatus) {
       ReservedMem: systemStatus.shift()[1],
       Labels: parseLabels(systemStatus.shift()[1]),
       Error: systemStatus.shift()[1],
-      UpdatedAt: systemStatus.shift()[1]
+      UpdatedAt: systemStatus.shift()[1],
+      ServerVersion: systemStatus.shift()[1]
     }
   }
 

--- a/test/fixtures/swarm-info.js
+++ b/test/fixtures/swarm-info.js
@@ -27,7 +27,8 @@ function hostEntry (hostInfo) {
     [ '  └ Reserved Memory', '10 GiB / 1.021 GiB' ],
     [ '  └ Labels', labelString ],
     [ '  └ Error', '(none)' ],
-    [ '  └ UpdatedAt', '2016-03-08T19:02:41Z' ]
+    [ '  └ UpdatedAt', '2016-03-08T19:02:41Z' ],
+    [ '  └ ServerVersion', '1.10.2' ]
   ]
 }
 


### PR DESCRIPTION
When we have swarm 1.2.0 the output is different. We need to parse a new field "ServerVersion".

This approach to horribly fragile but it works for now.
- [x] @anandkumarpatel
