### PR TITLE
SAN-4097; Swarm via Consul

### DIFF
--- a/consul.js
+++ b/consul.js
@@ -2,16 +2,16 @@
 
 var request = require('request')
 
-var CONSUL_HOST = process.env.CONSUL_HOST
 var SWARM_PREFIX = 'swarm/docker/swarm/nodes/'
 
 function Consul () {
-  if (!CONSUL_HOST) {
+  this.CONSUL_HOST = process.env.CONSUL_HOST
+  if (!this.CONSUL_HOST) {
     throw new Error('CONSUL_HOST must be defined')
   }
 }
 
-Consul._makeRequest = function (url, cb) {
+Consul.prototype._makeRequest = function (url, cb) {
   request.get(url, {}, function (err, res, body) {
     if (err) { return cb(err) }
     body = JSON.parse(body)
@@ -23,12 +23,12 @@ Consul._makeRequest = function (url, cb) {
   })
 }
 
-Consul._getRecursiveKV = function (prefix, cb) {
-  Consul._makeRequest('http://' + CONSUL_HOST + '/v1/kv/' + prefix + '?recurse=true', cb)
+Consul.prototype._getRecursiveKV = function (prefix, cb) {
+  this._makeRequest('http://' + this.CONSUL_HOST + '/v1/kv/' + prefix + '?recurse=true', cb)
 }
 
-Consul.getSwarmNodes = function (cb) {
-  Consul._getRecursiveKV(SWARM_PREFIX, function (err, hosts) {
+Consul.prototype.getSwarmNodes = function (cb) {
+  this._getRecursiveKV(SWARM_PREFIX, function (err, hosts) {
     if (err) { return cb(err) }
     hosts = hosts.map(function (p) {
       return p.Key.substr(SWARM_PREFIX.length)
@@ -38,4 +38,3 @@ Consul.getSwarmNodes = function (cb) {
 }
 
 module.exports = Consul
-

--- a/consul.js
+++ b/consul.js
@@ -1,0 +1,44 @@
+'use strict'
+
+var loadenv = require('loadenv')
+loadenv()
+
+var request = require('request')
+
+var CONSUL_HOST = process.env.CONSUL_HOST
+var SWARM_PREFIX = 'swarm/docker/swarm/nodes/'
+
+function Consul () {
+  if (!CONSUL_HOST) {
+    throw new Error('CONSUL_HOST must be defined')
+  }
+}
+
+Consul._makeRequest = function (url, cb) {
+  request.get(url, {}, function (err, res, body) {
+    if (err) { return cb(err) }
+    body = JSON.parse(body)
+    body = body.map(function (v) {
+      v.Value = v.Value ? (new Buffer(v.Value, 'base64')).toString('utf-8') : ''
+      return v
+    })
+    cb(null, body)
+  })
+}
+
+Consul._getRecursiveKV = function (prefix, cb) {
+  Consul._makeRequest('http://' + CONSUL_HOST + '/v1/kv/${prefix}?recurse=true', cb)
+}
+
+Consul.getSwarmNodes = function (cb) {
+  Consul._getRecursiveKV(SWARM_PREFIX, function (err, hosts) {
+    if (err) { return cb(err) }
+    hosts = hosts.map(function (p) {
+      return p.Key.substr(SWARM_PREFIX.length)
+    })
+    cb(null, hosts)
+  })
+}
+
+module.exports = Consul
+

--- a/consul.js
+++ b/consul.js
@@ -1,8 +1,5 @@
 'use strict'
 
-var loadenv = require('loadenv')
-loadenv()
-
 var request = require('request')
 
 var CONSUL_HOST = process.env.CONSUL_HOST

--- a/consul.js
+++ b/consul.js
@@ -14,7 +14,14 @@ function Consul () {
 Consul.prototype._makeRequest = function (url, cb) {
   request.get(url, {}, function (err, res, body) {
     if (err) { return cb(err) }
-    body = JSON.parse(body)
+    try {
+      body = JSON.parse(body)
+    } catch (parseErr) {
+      return cb(new Error('Parse Consul response error', { originalErr: parseErr }))
+    }
+    if (!Array.isArray(body)) {
+      return cb(new Error('Invalid Consul response'))
+    }
     body = body.map(function (v) {
       v.Value = v.Value ? (new Buffer(v.Value, 'base64')).toString('utf-8') : ''
       return v

--- a/consul.js
+++ b/consul.js
@@ -27,7 +27,7 @@ Consul._makeRequest = function (url, cb) {
 }
 
 Consul._getRecursiveKV = function (prefix, cb) {
-  Consul._makeRequest('http://' + CONSUL_HOST + '/v1/kv/${prefix}?recurse=true', cb)
+  Consul._makeRequest('http://' + CONSUL_HOST + '/v1/kv/' + prefix + '?recurse=true', cb)
 }
 
 Consul.getSwarmNodes = function (cb) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ function Swarmerode () {
  * @param {Function} cb Callback with signature (err, hosts).
  */
 Swarmerode.prototype.swarmHosts = function (cb) {
-  Consul.getSwarmNodes(cb)
+  var consul = new Consul()
+  consul.getSwarmNodes(cb)
 }
 
 /**
@@ -41,7 +42,8 @@ Swarmerode.prototype.swarmInfo = function (cb) {
  * @param {Function} cb Callback with signature (err, hostExists).
  */
 Swarmerode.prototype.swarmHostExists = function (host, cb) {
-  Consul.getSwarmNodes(function (err, hosts) {
+  var consul = new Consul()
+  consul.getSwarmNodes(function (err, hosts) {
     if (err) { return cb(err) }
     var index = hosts.indexOf(host)
     cb(null, index !== -1)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ var clone = require('101/clone')
 var debug = require('debug')('swarmerode')
 var exists = require('101/exists')
 
+var Consul = require('./consul')
+
 /*
  * Swarmerode Class constructor. Not really to be used but as a placeholder for
  * the functions with which we want to extend dockerode.
@@ -17,15 +19,7 @@ function Swarmerode () {
  * @param {Function} cb Callback with signature (err, hosts).
  */
 Swarmerode.prototype.swarmHosts = function (cb) {
-  this.swarmInfo(function (err, data) {
-    if (err) { return cb(err) }
-    var nodes = data.parsedSystemStatus.ParsedNodes
-    var hosts = Object.keys(nodes)
-      .map(function (key) {
-        return nodes[key].Host
-      })
-    cb(null, hosts)
-  })
+  Consul.getSwarmNodes(cb)
 }
 
 /**
@@ -47,7 +41,7 @@ Swarmerode.prototype.swarmInfo = function (cb) {
  * @param {Function} cb Callback with signature (err, hostExists).
  */
 Swarmerode.prototype.swarmHostExists = function (host, cb) {
-  this.swarmHosts(function (err, hosts) {
+  Consul.getSwarmNodes(function (err, hosts) {
     if (err) { return cb(err) }
     var index = hosts.indexOf(host)
     cb(null, index !== -1)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "101": "^1.2.0",
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "request": "^2.72.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/consul.js
+++ b/test/consul.js
@@ -59,6 +59,22 @@ describe('Consul', function () {
       })
     })
 
+    it('should fail with an error if response in not a JSON', function (done) {
+      request.get.yieldsAsync(null, null, 'not-a-josn')
+      consul._makeRequest('mockUrl', function (err) {
+        assert.equal(err.message, 'Parse Consul response error')
+        done()
+      })
+    })
+
+    it('should fail with an error if reposnse in not a JSON array', function (done) {
+      request.get.yieldsAsync(null, null, '{"a":1}')
+      consul._makeRequest('mockUrl', function (err) {
+        assert.equal(err.message, 'Invalid Consul response')
+        done()
+      })
+    })
+
     it('should decode values', function (done) {
       consul._makeRequest('mockUrl', function (err, body) {
         assert.isNull(err)

--- a/test/consul.js
+++ b/test/consul.js
@@ -1,0 +1,106 @@
+'use strict'
+
+var assert = require('chai').assert
+var sinon = require('sinon')
+var request = require('request')
+
+var Consul = require('../consul')
+
+describe('Consul', function () {
+  var mockRes = { statusCode: 200 }
+  var mockBody = JSON.stringify([{ Value: 'bW9ja1ZhbHVl' }])
+
+  beforeEach(function () {
+    sinon.stub(request, 'get').yieldsAsync(null, mockRes, mockBody)
+  })
+
+  afterEach(function () {
+    request.get.restore()
+  })
+
+  describe('_makeRequest', function () {
+    it('shoud reach out to a url', function (done) {
+      Consul._makeRequest('mockUrl', function (err, body) {
+        assert.isNull(err)
+        sinon.assert.calledOnce(request.get)
+        sinon.assert.calledWithExactly(
+          request.get,
+          'mockUrl',
+          {},
+          sinon.match.func
+        )
+        done()
+      })
+    })
+
+    it('should pass through any error', function (done) {
+      var error = new Error('yup')
+      request.get.yieldsAsync(error)
+      Consul._makeRequest('mockUrl', function (err) {
+        assert.equal(err, error)
+        done()
+      })
+    })
+
+    it('should decode values', function (done) {
+      Consul._makeRequest('mockUrl', function (err, body) {
+        assert.isNull(err)
+        assert.equal(body[0].Value, 'mockValue')
+        done()
+      })
+    })
+  })
+
+  describe('_getRecursiveKV', function (done) {
+    var mockParedBody = [{ Value: 'mockValue' }]
+    beforeEach(function () {
+      sinon.stub(Consul, '_makeRequest').yieldsAsync(null, mockParedBody)
+    })
+
+    afterEach(function () {
+      Consul._makeRequest.restore()
+    })
+
+    it('should call _makeRequest with a correct url', function (done) {
+      Consul._getRecursiveKV('my/prefix/', function (err, values) {
+        assert.isNull(err)
+        sinon.assert.calledWithExactly(
+          Consul._makeRequest,
+          sinon.match(/.+my\/prefix\/.+recurse=true$/),
+          sinon.match.func
+        )
+        assert.equal(values, mockParedBody)
+        done()
+      })
+    })
+  })
+
+  describe('getSwarmNodes', function (done) {
+    var mockParedBody = [{ Key: 'swarm/docker/swarm/nodes/mockValue' }]
+    beforeEach(function () {
+      sinon.stub(Consul, '_getRecursiveKV').yieldsAsync(null, mockParedBody)
+    })
+
+    afterEach(function () {
+      Consul._getRecursiveKV.restore()
+    })
+
+    it('should get the nodes', function (done) {
+      Consul.getSwarmNodes(function (err, nodes) {
+        assert.isNull(err)
+        assert.lengthOf(nodes, 1)
+        assert.equal(nodes[0], 'mockValue')
+        done()
+      })
+    })
+
+    it('should pass through any error', function (done) {
+      var error = new Error('robot')
+      Consul._getRecursiveKV.yieldsAsync(error)
+      Consul.getSwarmNodes(function (err, nodes) {
+        assert.equal(err, error)
+        done()
+      })
+    })
+  })
+})

--- a/test/index.js
+++ b/test/index.js
@@ -105,6 +105,26 @@ describe('Swarmerode', function () {
     })
   })
 
+  describe('swarmInfo', function () {
+    it('should call the class info function', function (done) {
+      sinon.spy(MockClass.prototype, 'info')
+      instance.swarmInfo(function (err) {
+        assert.isNull(err)
+        sinon.assert.calledOnce(MockClass.prototype.info)
+        done()
+      })
+    })
+
+    it('should pass through any info error', function (done) {
+      var error = new Error('foobar')
+      sinon.stub(MockClass.prototype, 'info').yieldsAsync(error)
+      instance.swarmInfo(function (err) {
+        assert.equal(err, error)
+        done()
+      })
+    })
+  })
+
   describe('swarmHostExists', function () {
     it('should return any error from consul', function (done) {
       var error = new Error('robot')

--- a/test/index.js
+++ b/test/index.js
@@ -19,16 +19,20 @@ var Swarmerode = require('../')
 describe('Swarmerode', function () {
   var MockClass
   var instance
+  var prevConsulHost = process.env.CONSUL_HOST
+
   beforeEach(function () {
+    process.env.CONSUL_HOST = 'somehost'
     MockClass = function () {}
     MockClass.prototype.info = function (cb) { cb(null, clone(testInfo)) }
     MockClass = Swarmerode(MockClass)
     instance = new MockClass()
-    sinon.stub(Consul, 'getSwarmNodes').yieldsAsync(null, exampleHosts)
+    sinon.stub(Consul.prototype, 'getSwarmNodes').yieldsAsync(null, exampleHosts)
   })
 
   afterEach(function () {
-    Consul.getSwarmNodes.restore()
+    Consul.prototype.getSwarmNodes.restore()
+    process.env.CONSUL_HOST = prevConsulHost
   })
 
   it('should extend a given class', function () {
@@ -88,7 +92,7 @@ describe('Swarmerode', function () {
   describe('swarmHosts', function () {
     it('should return any error from consul', function (done) {
       var error = new Error('robot')
-      Consul.getSwarmNodes.yieldsAsync(error)
+      Consul.prototype.getSwarmNodes.yieldsAsync(error)
       instance.swarmHosts(function (err) {
         assert.equal(err, error)
         done()
@@ -128,7 +132,7 @@ describe('Swarmerode', function () {
   describe('swarmHostExists', function () {
     it('should return any error from consul', function (done) {
       var error = new Error('robot')
-      Consul.getSwarmNodes.yieldsAsync(error)
+      Consul.prototype.getSwarmNodes.yieldsAsync(error)
       instance.swarmHostExists('10.0.0.1:4242', function (err) {
         assert.equal(err, error)
         done()

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,14 @@ var sinon = require('sinon')
 
 var exampleHosts = [ '10.0.0.1:4242', '10.0.0.2:4242', '10.0.0.3:4242' ]
 var swarmInfoMock = require('./fixtures/swarm-info')
-var testInfo = swarmInfoMock([{ host: exampleHosts[0] }, { host: exampleHosts[1] }, { host: exampleHosts[2] }])
+var testInfo = swarmInfoMock([
+  { host: exampleHosts[0] },
+  { host: exampleHosts[1] },
+  { host: exampleHosts[2] }
+])
+
+var Consul = require('../consul')
+
 var Swarmerode = require('../')
 
 describe('Swarmerode', function () {
@@ -17,6 +24,11 @@ describe('Swarmerode', function () {
     MockClass.prototype.info = function (cb) { cb(null, clone(testInfo)) }
     MockClass = Swarmerode(MockClass)
     instance = new MockClass()
+    sinon.stub(Consul, 'getSwarmNodes').yieldsAsync(null, exampleHosts)
+  })
+
+  afterEach(function () {
+    Consul.getSwarmNodes.restore()
   })
 
   it('should extend a given class', function () {
@@ -74,9 +86,9 @@ describe('Swarmerode', function () {
   })
 
   describe('swarmHosts', function () {
-    it('should return any error from docker', function (done) {
+    it('should return any error from consul', function (done) {
       var error = new Error('robot')
-      sinon.stub(MockClass.prototype, 'info').yieldsAsync(error)
+      Consul.getSwarmNodes.yieldsAsync(error)
       instance.swarmHosts(function (err) {
         assert.equal(err, error)
         done()
@@ -94,9 +106,9 @@ describe('Swarmerode', function () {
   })
 
   describe('swarmHostExists', function () {
-    it('should return any error from docker', function (done) {
+    it('should return any error from consul', function (done) {
       var error = new Error('robot')
-      sinon.stub(MockClass.prototype, 'info').yieldsAsync(error)
+      Consul.getSwarmNodes.yieldsAsync(error)
       instance.swarmHostExists('10.0.0.1:4242', function (err) {
         assert.equal(err, error)
         done()


### PR DESCRIPTION
This PR allows swarmerode to get the swarm hosts from consul. It does do a swarm `info` when it needs the org information, but this is much less load on swarm.

Reviewers:
- [x] @rsandor
- [x] @anandkumarpatel 
